### PR TITLE
Fix for sdcard1 on scorpion

### DIFF
--- a/rootdir/fstab.qcom
+++ b/rootdir/fstab.qcom
@@ -1,0 +1,13 @@
+# Android fstab file.
+#<src>                                              <mnt_point> <type> <mnt_flags and options> <fs_mgr_flags>
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+/dev/block/platform/msm_sdcc.1/by-name/boot         /boot      emmc   defaults recoveryonly
+/dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery  emmc   defaults recoveryonly
+/dev/block/platform/msm_sdcc.1/by-name/system       /system    ext4   ro,barrier=1 wait
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache     ext4   noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data      ext4   noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,encryptable=footer,length=-16384
+
+/devices/msm_sdcc.3/mmc_host     auto auto defaults voldmanaged=sdcard1:auto
+/devices/platform/xhci-hcd       auto auto defaults voldmanaged=usbdisk:auto


### PR DESCRIPTION
scorpion has sdcard1 on /devices/msm_sdcc.3/mmc_host

I am not sure how to propose this change but the current CM12 build for scorpion_windy has /devices/msm_sdcc.2/mmc_host which is not correct.
